### PR TITLE
Support sector size of 4096 bytes

### DIFF
--- a/xfs/ag.go
+++ b/xfs/ag.go
@@ -112,7 +112,8 @@ type BtreeShortBlock struct {
 
 func parseSuperBlock(r io.Reader) (SuperBlock, error) {
 	var sb SuperBlock
-	buf, err := utils.ReadSector(r)
+	chunkReader := utils.DefaultChunkReader()
+	buf, err := chunkReader.ReadSector(r)
 	if err != nil {
 		return SuperBlock{}, xerrors.Errorf("failed to create superblock reader: %w", err)
 	}
@@ -135,7 +136,8 @@ func ParseAG(reader io.Reader) (*AG, error) {
 		return nil, xerrors.Errorf("failed to parse super block: %w", err)
 	}
 
-	buf, err := utils.ReadSector(r)
+	chunkRedaer := utils.DefaultChunkReader()
+	buf, err := chunkRedaer.ReadSector(r)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to create afg reader: %w", err)
 	}
@@ -146,7 +148,7 @@ func ParseAG(reader io.Reader) (*AG, error) {
 		return nil, xerrors.Errorf("failed to parse agf magic byte error: %08x", ag.Agf.Magicnum)
 	}
 
-	buf, err = utils.ReadSector(r)
+	buf, err = chunkRedaer.ReadSector(r)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to create agi reader: %w", err)
 	}
@@ -157,7 +159,7 @@ func ParseAG(reader io.Reader) (*AG, error) {
 		return nil, xerrors.Errorf("failed to parse agi magic byte error: %08x", ag.Agi.Magicnum)
 	}
 
-	buf, err = utils.ReadSector(r)
+	buf, err = chunkRedaer.ReadSector(r)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to create agfl reader: %w", err)
 	}

--- a/xfs/ag.go
+++ b/xfs/ag.go
@@ -136,7 +136,11 @@ func ParseAG(reader io.Reader) (*AG, error) {
 		return nil, xerrors.Errorf("failed to parse super block: %w", err)
 	}
 
-	chunkRedaer := utils.DefaultChunkReader()
+	chunkRedaer, err := utils.NewChunkReader(int(ag.SuperBlock.Sectsize))
+	if err != nil {
+		return nil, xerrors.Errorf("failed to create chunk reader: %w", err)
+	}
+
 	buf, err := chunkRedaer.ReadSector(r)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to create afg reader: %w", err)

--- a/xfs/inode.go
+++ b/xfs/inode.go
@@ -474,7 +474,7 @@ func (xfs *FileSystem) ParseInode(ino uint64) (*Inode, error) {
 		return nil, xerrors.Errorf("failed to seek inode: %w", err)
 	}
 
-	sectorReader, err := utils.NewSectorReader(int(xfs.PrimaryAG.SuperBlock.Sectsize))
+	sectorReader, err := utils.NewSectorReader(int(xfs.PrimaryAG.SuperBlock.Inodesize))
 	if err != nil {
 		return nil, xerrors.Errorf("failed to create sector reader: %w", err)
 	}

--- a/xfs/inode.go
+++ b/xfs/inode.go
@@ -474,7 +474,8 @@ func (xfs *FileSystem) ParseInode(ino uint64) (*Inode, error) {
 		return nil, xerrors.Errorf("failed to seek inode: %w", err)
 	}
 
-	buf, err := utils.ReadSector(xfs.r)
+	chunkReader := utils.DefaultChunkReader()
+	buf, err := chunkReader.ReadSector(xfs.r)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to read sector: %w", err)
 	}
@@ -732,7 +733,8 @@ func (xfs *FileSystem) parseDir2Block(bmbtIrec BmbtIrec) (*Dir2Block, error) {
 	}
 
 	// TODO: add tests, If Block count greater than 2
-	b, err := utils.ReadBlock(xfs.r)
+	chunkReader := utils.DefaultChunkReader()
+	b, err := chunkReader.ReadBlock(xfs.r)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to read block: %w", err)
 	}

--- a/xfs/inode.go
+++ b/xfs/inode.go
@@ -474,8 +474,11 @@ func (xfs *FileSystem) ParseInode(ino uint64) (*Inode, error) {
 		return nil, xerrors.Errorf("failed to seek inode: %w", err)
 	}
 
-	chunkReader := utils.DefaultChunkReader()
-	buf, err := chunkReader.ReadSector(xfs.r)
+	sectorReader, err := utils.NewSectorReader(int(xfs.PrimaryAG.SuperBlock.Sectsize))
+	if err != nil {
+		return nil, xerrors.Errorf("failed to create sector reader: %w", err)
+	}
+	buf, err := sectorReader.ReadSector(xfs.r)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to read sector: %w", err)
 	}
@@ -733,8 +736,7 @@ func (xfs *FileSystem) parseDir2Block(bmbtIrec BmbtIrec) (*Dir2Block, error) {
 	}
 
 	// TODO: add tests, If Block count greater than 2
-	chunkReader := utils.DefaultChunkReader()
-	b, err := chunkReader.ReadBlock(xfs.r)
+	b, err := utils.ReadBlock(xfs.r)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to read block: %w", err)
 	}

--- a/xfs/utils/utils.go
+++ b/xfs/utils/utils.go
@@ -19,6 +19,26 @@ func DefaultChunkReader() *chunkReader {
 	}
 }
 
+var allowedSectorSize = []int{512, 4096}
+
+func NewChunkReader(sectorSize int) (*chunkReader, error) {
+	validSectorSize := false
+	for _, s := range allowedSectorSize {
+		if s == sectorSize {
+			validSectorSize = true
+			break
+		}
+	}
+	if !validSectorSize {
+		return nil, fmt.Errorf("failed to instantiate chunk reader, invalid sector size: %d", sectorSize)
+	}
+
+	return &chunkReader{
+		blockSize:  BlockSize,
+		sectorSize: sectorSize,
+	}, nil
+}
+
 type chunkReader struct {
 	blockSize  int
 	sectorSize int

--- a/xfs/xfs.go
+++ b/xfs/xfs.go
@@ -363,24 +363,20 @@ func (xfs *FileSystem) listEntries(ino uint64) ([]Entry, error) {
 
 		for _, b := range inode.directoryExtents.bmbtRecs {
 			p := b.Unpack()
-			for i := 0; i < int(p.BlockCount); i++ {
-				block, err := xfs.parseDir2Block(p)
-				if err != nil {
-					if !xerrors.Is(err, UnsupportedDir2BlockHeaderErr) {
-						return nil, xerrors.Errorf("failed to parse dir2 block: %w", err)
-					}
-					log.Logger.Warn(err)
+			block, err := xfs.parseDir2Block(p)
+			if err != nil {
+				if !xerrors.Is(err, UnsupportedDir2BlockHeaderErr) {
+					return nil, xerrors.Errorf("failed to parse dir2 block: %w", err)
 				}
+				log.Logger.Warn(err)
+			}
 
-				if block == nil {
-					break
-				}
+			if block == nil {
+				break
+			}
 
-				for _, entry := range block.Entries {
-					entries = append(entries, entry)
-				}
-				p.StartBlock++
-				p.StartOff++
+			for _, entry := range block.Entries {
+				entries = append(entries, entry)
 			}
 		}
 	} else {

--- a/xfs/xfs.go
+++ b/xfs/xfs.go
@@ -254,8 +254,9 @@ func (xfs *FileSystem) seekBlock(n int64) (int64, error) {
 
 func (xfs *FileSystem) readBlock(count uint32) ([]byte, error) {
 	buf := make([]byte, 0, xfs.PrimaryAG.SuperBlock.BlockSize*count)
+	chunkReader := utils.DefaultChunkReader()
 	for i := uint32(0); i < count; i++ {
-		b, err := utils.ReadBlock(xfs.r)
+		b, err := chunkReader.ReadBlock(xfs.r)
 		if err != nil {
 			return nil, err
 		}

--- a/xfs/xfs.go
+++ b/xfs/xfs.go
@@ -254,9 +254,8 @@ func (xfs *FileSystem) seekBlock(n int64) (int64, error) {
 
 func (xfs *FileSystem) readBlock(count uint32) ([]byte, error) {
 	buf := make([]byte, 0, xfs.PrimaryAG.SuperBlock.BlockSize*count)
-	chunkReader := utils.DefaultChunkReader()
 	for i := uint32(0); i < count; i++ {
-		b, err := chunkReader.ReadBlock(xfs.r)
+		b, err := utils.ReadBlock(xfs.r)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
**Background:**
`ReadSector` was a static method with hard-coded sector size of 512.
Instead, I implemented the function as part of a new struct `sectorReader` that can accept `sectorSize`.
In this pr, I initialize the `sectorReader` with the sector size found in the superblock of the AG.

**Related issues:**
- https://github.com/masahiro331/go-xfs-filesystem/issues/3