### PR TITLE
Fix file mode bit handling

### DIFF
--- a/xfs/inode.go
+++ b/xfs/inode.go
@@ -834,19 +834,19 @@ func parseEntry(r io.Reader, i8count bool) (*Dir2SfEntry, error) {
 }
 
 func (ic InodeCore) IsDir() bool {
-	return ic.Mode&0x4000 != 0 && ic.Mode&0x8000 == 0
+	return ic.Mode&0xF000 == 0x4000
 }
 
 func (ic InodeCore) IsRegular() bool {
-	return ic.Mode&0x8000 != 0 && ic.Mode&0x4000 == 0
+	return ic.Mode&0xF000 == 0x8000
 }
 
 func (ic InodeCore) IsSocket() bool {
-	return ic.Mode&0xC000 != 0
+	return ic.Mode&0xF000 == 0xC000
 }
 
 func (ic InodeCore) IsSymlink() bool {
-	return ic.Mode&0xA000 != 0
+	return ic.Mode&0xF000 == 0xA000
 }
 
 func (ic InodeCore) isSupported() bool {

--- a/xfs/xfs_test.go
+++ b/xfs/xfs_test.go
@@ -25,19 +25,19 @@ func TestFileSystemCheckFileExtents(t *testing.T) {
 			filesystem:   "testdata/image.xfs",
 			name:         "fmt_extents_file_1024",
 			expectedSize: 1024,
-			mode:         33188,
+			mode:         0o644,
 		},
 		{
 			filesystem:   "testdata/image.xfs",
 			name:         "fmt_extents_file_4096",
 			expectedSize: 4096,
-			mode:         33188,
+			mode:         0o644,
 		},
 		{
 			filesystem:   "testdata/image.xfs",
 			name:         "fmt_extents_file_16384",
 			expectedSize: 16384,
-			mode:         33188,
+			mode:         0o644,
 		},
 		{
 			filesystem:  "testdata/image.xfs",


### PR DESCRIPTION
fs.FileMode specifies a number of bits that do not match the file mode bits defined in the inode, so constructing a valid fs.FileMode requires translating bits 9-16 into the equivalent flags defined in fs package vs just casting the filemode bits from the inode.

In addition, the IsDir method in inode was incorrect - a block device has the value 0x6000, which means IsDir will return true for block device nodes.